### PR TITLE
Align comment and post controllers with database user model

### DIFF
--- a/src/main/java/com/banma/forum/controller/CommentServlet.java
+++ b/src/main/java/com/banma/forum/controller/CommentServlet.java
@@ -1,22 +1,34 @@
 package com.banma.forum.controller;
 
-import com.banma.forum.store.MemoryStore;
+import com.banma.forum.dao.ReplyDao;
+import com.banma.forum.model.User;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.*;
 import java.io.IOException;
+import java.sql.SQLException;
 
 public class CommentServlet extends HttpServlet {
+    private final ReplyDao replyDao = new ReplyDao();
+
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp)
             throws ServletException, IOException {
-        MemoryStore.User u = (MemoryStore.User) req.getSession().getAttribute("user");
+        HttpSession session = req.getSession(false);
+        User u = session != null ? (User) session.getAttribute("user") : null;
         if (u == null) { resp.sendRedirect(req.getContextPath()+"/auth/login"); return; }
         String path = req.getPathInfo(); // /add
         if ("/add".equals(path)) {
-            int postId = Integer.parseInt(req.getParameter("postId"));
-            String content = req.getParameter("content");
-            MemoryStore.addComment(postId, u.getId(), content);
-            resp.sendRedirect(req.getContextPath()+"/post/detail?id="+postId);
+            try {
+                int postId = Integer.parseInt(req.getParameter("postId"));
+                String content = req.getParameter("content");
+                replyDao.add(postId, u.getId(), content);
+                resp.sendRedirect(req.getContextPath()+"/post/detail?id="+postId);
+            } catch (NumberFormatException e) {
+                resp.sendError(400, "帖子ID不合法");
+            } catch (SQLException e) {
+                throw new ServletException(e);
+            }
         } else {
             resp.sendError(404);
         }

--- a/src/main/java/com/banma/forum/controller/PostServlet.java
+++ b/src/main/java/com/banma/forum/controller/PostServlet.java
@@ -2,7 +2,7 @@ package com.banma.forum.controller;
 
 import com.banma.forum.dao.PostDao;
 import com.banma.forum.dao.ReplyDao;
-import com.banma.forum.store.MemoryStore; // 仅复用你已有的 User POJO；若你已换成 model.User，改成对应类即可
+import com.banma.forum.model.User;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.*;
@@ -57,7 +57,8 @@ public class PostServlet extends HttpServlet {
 
             if ("/delete".equals(path)) {
                 // 展示确认页（仅作者能看到按钮，但这里仍要校验）
-                MemoryStore.User current = (MemoryStore.User) req.getSession().getAttribute("user");
+                HttpSession session = req.getSession(false);
+                User current = session != null ? (User) session.getAttribute("user") : null;
                 if (current == null) { resp.sendRedirect(req.getContextPath()+"/auth/login"); return; }
 
                 int id = parseIntOr404(req.getParameter("id"), resp);
@@ -85,7 +86,8 @@ public class PostServlet extends HttpServlet {
             throws ServletException, IOException {
 
         String path = req.getPathInfo();
-        MemoryStore.User current = (MemoryStore.User) req.getSession().getAttribute("user");
+        HttpSession session = req.getSession(false);
+        User current = session != null ? (User) session.getAttribute("user") : null;
         if (current == null) { resp.sendRedirect(req.getContextPath()+"/auth/login"); return; }
 
         try {


### PR DESCRIPTION
## Summary
- switch post and comment servlets to use the database-backed User entity from the session
- replace in-memory comment writes with ReplyDao persistence and add error handling

## Testing
- `mvn -q -DskipTests package` *(fails: plugin download blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68ce25beb7fc832887b327eb671df080