### PR TITLE
Fix board pages to use DB models and restore UI styling

### DIFF
--- a/src/main/java/com/banma/forum/controller/CommentServlet.java
+++ b/src/main/java/com/banma/forum/controller/CommentServlet.java
@@ -1,24 +1,51 @@
 package com.banma.forum.controller;
 
-import com.banma.forum.store.MemoryStore;
+import com.banma.forum.dao.ReplyDao;
+import com.banma.forum.model.User;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.*;
 import java.io.IOException;
+import java.sql.SQLException;
 
 public class CommentServlet extends HttpServlet {
+    private final ReplyDao replyDao = new ReplyDao();
+
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp)
             throws ServletException, IOException {
-        MemoryStore.User u = (MemoryStore.User) req.getSession().getAttribute("user");
+        HttpSession session = req.getSession(false);
+        User u = session != null ? (User) session.getAttribute("user") : null;
         if (u == null) { resp.sendRedirect(req.getContextPath()+"/auth/login"); return; }
         String path = req.getPathInfo(); // /add
         if ("/add".equals(path)) {
-            int postId = Integer.parseInt(req.getParameter("postId"));
-            String content = req.getParameter("content");
-            MemoryStore.addComment(postId, u.getId(), content);
-            resp.sendRedirect(req.getContextPath()+"/post/detail?id="+postId);
+            try {
+                int postId = Integer.parseInt(req.getParameter("postId"));
+                String content = trim(req.getParameter("content"));
+
+                if (content == null || content.isEmpty()) {
+                    resp.sendRedirect(req.getContextPath()+"/post/detail?id="+postId+"&error=empty");
+                    return;
+                }
+
+                if (content.length() > 1000) {
+                    resp.sendRedirect(req.getContextPath()+"/post/detail?id="+postId+"&error=toolong");
+                    return;
+                }
+
+                replyDao.add(postId, u.getId(), content);
+                resp.sendRedirect(req.getContextPath()+"/post/detail?id="+postId);
+            } catch (NumberFormatException e) {
+                resp.sendError(400, "帖子ID不合法");
+            } catch (SQLException e) {
+                throw new ServletException(e);
+            }
         } else {
             resp.sendError(404);
         }
+    }
+
+    private String trim(String s) {
+        return s == null ? null : s.trim();
     }
 }

--- a/src/main/java/com/banma/forum/controller/PostServlet.java
+++ b/src/main/java/com/banma/forum/controller/PostServlet.java
@@ -1,8 +1,9 @@
 package com.banma.forum.controller;
 
+import com.banma.forum.dao.BoardDao;
 import com.banma.forum.dao.PostDao;
 import com.banma.forum.dao.ReplyDao;
-import com.banma.forum.store.MemoryStore; // 仅复用你已有的 User POJO；若你已换成 model.User，改成对应类即可
+import com.banma.forum.model.User;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.*;
@@ -22,6 +23,7 @@ import java.util.*;
 public class PostServlet extends HttpServlet {
     private final PostDao postDao = new PostDao();
     private final ReplyDao replyDao = new ReplyDao();
+    private final BoardDao boardDao = new BoardDao();
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp)
@@ -31,7 +33,18 @@ public class PostServlet extends HttpServlet {
 
         try {
             if ("/new".equals(path)) {
-                // 打开发帖页
+                String bidParam = req.getParameter("bid");
+                Integer boardId = parseIntOrNull(bidParam);
+                if (bidParam != null && !bidParam.trim().isEmpty() && boardId == null) {
+                    resp.sendError(404);
+                    return;
+                }
+                if (boardId != null) {
+                    Map<String,Object> board = boardDao.findById(boardId);
+                    if (board == null) { resp.sendError(404); return; }
+                    req.setAttribute("board", board);
+                    req.setAttribute("boardId", boardId);
+                }
                 req.getRequestDispatcher("/WEB-INF/views/post.jsp").forward(req, resp);
                 return;
             }
@@ -44,20 +57,34 @@ public class PostServlet extends HttpServlet {
                 if (post == null) { resp.sendError(404); return; }
 
                 req.setAttribute("post", post);
-                req.setAttribute("comments", replyDao.listByPost(id));
+                req.setAttribute("replies", replyDao.listByPost(id));
                 req.getRequestDispatcher("/WEB-INF/views/post_detail.jsp").forward(req, resp);
                 return;
             }
 
-            if ("/list".equals(path) || path == null || "/".equals(path)) {
-                req.setAttribute("posts", postDao.list(0, 100));
+            if (path == null || "/".equals(path) || "/list".equals(path)) {
+                String bidParam = req.getParameter("bid");
+                Integer boardId = parseIntOrNull(bidParam);
+                if (bidParam != null && !bidParam.trim().isEmpty() && boardId == null) {
+                    resp.sendError(404);
+                    return;
+                }
+                if (boardId != null) {
+                    Map<String,Object> board = boardDao.findById(boardId);
+                    if (board == null) { resp.sendError(404); return; }
+                    req.setAttribute("board", board);
+                    req.setAttribute("posts", postDao.listByBoard(boardId, 0, 100));
+                } else {
+                    req.setAttribute("posts", postDao.list(0, 100));
+                }
                 req.getRequestDispatcher("/WEB-INF/views/list.jsp").forward(req, resp);
                 return;
             }
 
             if ("/delete".equals(path)) {
                 // 展示确认页（仅作者能看到按钮，但这里仍要校验）
-                MemoryStore.User current = (MemoryStore.User) req.getSession().getAttribute("user");
+                HttpSession session = req.getSession(false);
+                User current = session != null ? (User) session.getAttribute("user") : null;
                 if (current == null) { resp.sendRedirect(req.getContextPath()+"/auth/login"); return; }
 
                 int id = parseIntOr404(req.getParameter("id"), resp);
@@ -85,23 +112,40 @@ public class PostServlet extends HttpServlet {
             throws ServletException, IOException {
 
         String path = req.getPathInfo();
-        MemoryStore.User current = (MemoryStore.User) req.getSession().getAttribute("user");
+        HttpSession session = req.getSession(false);
+        User current = session != null ? (User) session.getAttribute("user") : null;
         if (current == null) { resp.sendRedirect(req.getContextPath()+"/auth/login"); return; }
 
         try {
             if ("/create".equals(path)) {
                 String title = trim(req.getParameter("title"));
                 String content = trim(req.getParameter("content"));
-                // 可以从页面带一个板块 bid；若暂时没有，就给个 Java 板块 6 的默认值
-                int bid = parseIntOrDefault(req.getParameter("bid"), 6);
+                Integer boardId = parseIntOrNull(req.getParameter("bid"));
 
-                if (isEmpty(title) || isEmpty(content)) {
-                    req.setAttribute("msg", "标题和内容不能为空");
+                if (boardId == null) {
+                    req.setAttribute("msg", "请选择有效的版块后再发帖");
+                    req.setAttribute("boardId", req.getParameter("bid"));
                     req.getRequestDispatcher("/WEB-INF/views/post.jsp").forward(req, resp);
                     return;
                 }
 
-                int tid = postDao.create(current.getId(), bid, title, content);
+                Map<String,Object> board = boardDao.findById(boardId);
+                if (board == null) {
+                    req.setAttribute("msg", "版块不存在或已被删除");
+                    req.setAttribute("boardId", boardId);
+                    req.getRequestDispatcher("/WEB-INF/views/post.jsp").forward(req, resp);
+                    return;
+                }
+
+                if (isEmpty(title) || isEmpty(content)) {
+                    req.setAttribute("msg", "标题和内容不能为空");
+                    req.setAttribute("board", board);
+                    req.setAttribute("boardId", boardId);
+                    req.getRequestDispatcher("/WEB-INF/views/post.jsp").forward(req, resp);
+                    return;
+                }
+
+                int tid = postDao.create(current.getId(), boardId, title, content);
                 resp.sendRedirect(req.getContextPath()+"/post/detail?id="+tid);
                 return;
             }
@@ -127,8 +171,15 @@ public class PostServlet extends HttpServlet {
         if (s == null) { resp.sendError(404); return -1; }
         try { return Integer.parseInt(s); } catch (NumberFormatException e) { resp.sendError(404); return -1; }
     }
-    private int parseIntOrDefault(String s, int def) {
-        try { return Integer.parseInt(s); } catch (Exception e) { return def; }
+    private Integer parseIntOrNull(String s) {
+        if (s == null || s.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(s.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
     private boolean isEmpty(String s){ return s==null || s.trim().isEmpty(); }
     private String trim(String s){ return s==null? null : s.trim(); }

--- a/src/main/java/com/banma/forum/dao/BoardDao.java
+++ b/src/main/java/com/banma/forum/dao/BoardDao.java
@@ -1,0 +1,30 @@
+package com.banma.forum.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+/** 板块数据访问 */
+public class BoardDao {
+
+    /** 根据板块 ID 查询板块信息 */
+    public Map<String, Object> findById(int bid) throws SQLException {
+        final String sql = "SELECT bid, name FROM bankuai WHERE bid=?";
+        try (Connection c = DB.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, bid);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    return null;
+                }
+                Map<String, Object> board = new HashMap<>();
+                board.put("id", rs.getInt("bid"));
+                board.put("name", rs.getString("name"));
+                return board;
+            }
+        }
+    }
+}

--- a/src/main/webapp/WEB-INF/views/_inc/header.jspf
+++ b/src/main/webapp/WEB-INF/views/_inc/header.jspf
@@ -1,19 +1,19 @@
 <!-- 不要在片段里写 page/taglib 指令 -->
 <div class="topbar">
     <div class="wrap">
-        <a class="logo" href="${ctx}/">
-            <img src="${ctx}/images/logo.png" alt="Banma School" />
+        <a class="logo" href="${pageContext.request.contextPath}/">
+            <img src="${pageContext.request.contextPath}/assets/images/logo.png" alt="Banma School" />
         </a>
         <div class="userbar">
             <c:choose>
                 <c:when test="${not empty sessionScope.user}">
-                    您好：<strong>${sessionScope.user.username}</strong> |
-                    <a href="${ctx}/auth/logout">登出</a>
+                    您好：<strong><c:out value="${sessionScope.user.username}"/></strong> |
+                    <a href="${pageContext.request.contextPath}/auth/logout">登出</a>
                 </c:when>
                 <c:otherwise>
                     您尚未 |
-                    <a href="${ctx}/auth/login">登录</a> |
-                    <a href="${ctx}/auth/register">注册</a>
+                    <a href="${pageContext.request.contextPath}/auth/login">登录</a> |
+                    <a href="${pageContext.request.contextPath}/auth/register">注册</a>
                 </c:otherwise>
             </c:choose>
         </div>
@@ -21,7 +21,7 @@
 </div>
 <div class="breadcrumb">
     <div class="wrap">
-        >> <a href="${ctx}/">论坛首页</a>
+        >> <a href="${pageContext.request.contextPath}/">论坛首页</a>
         <c:if test="${not empty requestScope.breadcrumb}">
             ${requestScope.breadcrumb}
         </c:if>

--- a/src/main/webapp/WEB-INF/views/delete.jsp
+++ b/src/main/webapp/WEB-INF/views/delete.jsp
@@ -1,13 +1,35 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c"   uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ include file="/WEB-INF/views/_inc/header.jspf" %>
 
-<h3>确认删除</h3>
-<p>确定要删除帖子：<strong>${post.title}</strong> ？该操作不可恢复。</p>
-<form action="${pageContext.request.contextPath}/post/delete" method="post">
-  <input type="hidden" name="id" value="${post.tid}">
-  <button type="submit" class="btn danger">确认删除</button>
-  <a class="btn" href="${pageContext.request.contextPath}/post/detail?id=${post.tid}">取消</a>
-</form>
+<c:set var="breadcrumb" scope="request">
+    >> <a href="${pageContext.request.contextPath}/post/detail?id=${post.id}"><c:out value="${post.title}"/></a>
+    >> 删除确认
+</c:set>
 
-<%@ include file="/WEB-INF/views/_inc/footer.jspf" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>删除帖子 - 斑马教育 论坛</title>
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/assets/css/style.css">
+</head>
+<body>
+<jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
+
+<div class="wrap">
+    <div class="panel">
+        <div class="hd">确认删除</div>
+        <div class="bd">
+            <p>确定要删除帖子：<strong><c:out value="${post.title}"/></strong>？该操作不可恢复。</p>
+            <form action="${pageContext.request.contextPath}/post/delete" method="post" style="margin-top:16px;">
+                <input type="hidden" name="id" value="${post.id}">
+                <button type="submit" class="btn danger">确认删除</button>
+                <a class="btn secondary" href="${pageContext.request.contextPath}/post/detail?id=${post.id}" style="margin-left:12px;">取消</a>
+            </form>
+        </div>
+    </div>
+</div>
+
+<jsp:include page="/WEB-INF/views/_inc/footer.jspf"/>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -1,13 +1,11 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<c:set var="ctx" value="${pageContext.request.contextPath}" />
-
 <!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
     <title>斑马教育 论坛</title>
-    <link rel="stylesheet" href="${ctx}/style.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/assets/css/style.css">
 </head>
 <body>
 
@@ -32,23 +30,23 @@
             <!-- 动态循环（如果 servlet 设置了 netBoards 列表） -->
             <c:forEach items="${netBoards}" var="b">
                 <tr>
-                    <td class="board-icon"><img src="${ctx}/images/folder.png" alt=""></td>
-                    <td><a href="${ctx}/list?bid=${b.id}">${b.name}</a></td>
-                    <td>${b.topicCount}</td>
+                    <td class="board-icon"><img src="${pageContext.request.contextPath}/assets/images/board.gif" alt=""></td>
+                    <td><a href="${pageContext.request.contextPath}/post/list?bid=${b.id}"><c:out value="${b.name}"/></a></td>
+                    <td><c:out value="${b.topicCount}"/></td>
                     <td>
-                        <a href="${ctx}/post/detail?id=${b.lastPostId}">${b.lastPostTitle}</a>
-                        <span class="tip">${b.lastPostUser} [ ${b.lastPostTime} ]</span>
+                        <a href="${pageContext.request.contextPath}/post/detail?id=${b.lastPostId}"><c:out value="${b.lastPostTitle}"/></a>
+                        <span class="tip"><c:out value="${b.lastPostUser}"/> [ <c:out value="${b.lastPostTime}"/> ]</span>
                     </td>
                 </tr>
             </c:forEach>
             <!-- 没有数据时展示一行示例，保证页面不空白 -->
             <c:if test="${empty netBoards}">
                 <tr>
-                    <td class="board-icon"><img src="${ctx}/images/folder.png" alt=""></td>
-                    <td><a href="${ctx}/list?bid=2">C#技术</a></td>
+                    <td class="board-icon"><img src="${pageContext.request.contextPath}/assets/images/board.gif" alt=""></td>
+                    <td><a href="${pageContext.request.contextPath}/post/list?bid=2">C#技术</a></td>
                     <td>30</td>
                     <td>
-                        <a href="${ctx}/post/detail?id=1001">c#是微软开发的语言</a>
+                        <a href="${pageContext.request.contextPath}/post/detail?id=1001">c#是微软开发的语言</a>
                         <span class="tip">accp [ 2007-07-30 10:25 ]</span>
                     </td>
                 </tr>
@@ -72,22 +70,22 @@
             <tbody>
             <c:forEach items="${javaBoards}" var="b">
                 <tr>
-                    <td class="board-icon"><img src="${ctx}/images/folder.png" alt=""></td>
-                    <td><a href="${ctx}/list?bid=${b.id}">${b.name}</a></td>
-                    <td>${b.topicCount}</td>
+                    <td class="board-icon"><img src="${pageContext.request.contextPath}/assets/images/board.gif" alt=""></td>
+                    <td><a href="${pageContext.request.contextPath}/post/list?bid=${b.id}"><c:out value="${b.name}"/></a></td>
+                    <td><c:out value="${b.topicCount}"/></td>
                     <td>
-                        <a href="${ctx}/post/detail?id=${b.lastPostId}">${b.lastPostTitle}</a>
-                        <span class="tip">${b.lastPostUser} [ ${b.lastPostTime} ]</span>
+                        <a href="${pageContext.request.contextPath}/post/detail?id=${b.lastPostId}"><c:out value="${b.lastPostTitle}"/></a>
+                        <span class="tip"><c:out value="${b.lastPostUser}"/> [ <c:out value="${b.lastPostTime}"/> ]</span>
                     </td>
                 </tr>
             </c:forEach>
             <c:if test="${empty javaBoards}">
                 <tr>
-                    <td class="board-icon"><img src="${ctx}/images/folder.png" alt=""></td>
-                    <td><a href="${ctx}/list?bid=7">Java基础</a></td>
+                    <td class="board-icon"><img src="${pageContext.request.contextPath}/assets/images/board.gif" alt=""></td>
+                    <td><a href="${pageContext.request.contextPath}/post/list?bid=7">Java基础</a></td>
                     <td>2</td>
                     <td>
-                        <a href="${ctx}/post/detail?id=2001">你是谁，得斯阿学习Java</a>
+                        <a href="${pageContext.request.contextPath}/post/detail?id=2001">你是谁，得斯阿学习Java</a>
                         <span class="tip">aptech [ 2007-07-30 10:29 ]</span>
                     </td>
                 </tr>
@@ -111,22 +109,22 @@
             <tbody>
             <c:forEach items="${dbBoards}" var="b">
                 <tr>
-                    <td class="board-icon"><img src="${ctx}/images/folder.png" alt=""></td>
-                    <td><a href="${ctx}/list?bid=${b.id}">${b.name}</a></td>
-                    <td>${b.topicCount}</td>
+                    <td class="board-icon"><img src="${pageContext.request.contextPath}/assets/images/board.gif" alt=""></td>
+                    <td><a href="${pageContext.request.contextPath}/post/list?bid=${b.id}"><c:out value="${b.name}"/></a></td>
+                    <td><c:out value="${b.topicCount}"/></td>
                     <td>
-                        <a href="${ctx}/post/detail?id=${b.lastPostId}">${b.lastPostTitle}</a>
-                        <span class="tip">${b.lastPostUser} [ ${b.lastPostTime} ]</span>
+                        <a href="${pageContext.request.contextPath}/post/detail?id=${b.lastPostId}"><c:out value="${b.lastPostTitle}"/></a>
+                        <span class="tip"><c:out value="${b.lastPostUser}"/> [ <c:out value="${b.lastPostTime}"/> ]</span>
                     </td>
                 </tr>
             </c:forEach>
             <c:if test="${empty dbBoards}">
                 <tr>
-                    <td class="board-icon"><img src="${ctx}/images/folder.png" alt=""></td>
-                    <td><a href="${ctx}/list?bid=12">SQL Server基础</a></td>
+                    <td class="board-icon"><img src="${pageContext.request.contextPath}/assets/images/board.gif" alt=""></td>
+                    <td><a href="${pageContext.request.contextPath}/post/list?bid=12">SQL Server基础</a></td>
                     <td>2</td>
                     <td>
-                        <a href="${ctx}/post/detail?id=3001">记得SQL很容易</a>
+                        <a href="${pageContext.request.contextPath}/post/detail?id=3001">记得SQL很容易</a>
                         <span class="tip">aptech [ 2007-07-30 10:30 ]</span>
                     </td>
                 </tr>
@@ -150,22 +148,22 @@
             <tbody>
             <c:forEach items="${funBoards}" var="b">
                 <tr>
-                    <td class="board-icon"><img src="${ctx}/images/folder.png" alt=""></td>
-                    <td><a href="${ctx}/list?bid=${b.id}">${b.name}</a></td>
-                    <td>${b.topicCount}</td>
+                    <td class="board-icon"><img src="${pageContext.request.contextPath}/assets/images/board.gif" alt=""></td>
+                    <td><a href="${pageContext.request.contextPath}/post/list?bid=${b.id}"><c:out value="${b.name}"/></a></td>
+                    <td><c:out value="${b.topicCount}"/></td>
                     <td>
-                        <a href="${ctx}/post/detail?id=${b.lastPostId}">${b.lastPostTitle}</a>
-                        <span class="tip">${b.lastPostUser} [ ${b.lastPostTime} ]</span>
+                        <a href="${pageContext.request.contextPath}/post/detail?id=${b.lastPostId}"><c:out value="${b.lastPostTitle}"/></a>
+                        <span class="tip"><c:out value="${b.lastPostUser}"/> [ <c:out value="${b.lastPostTime}"/> ]</span>
                     </td>
                 </tr>
             </c:forEach>
             <c:if test="${empty funBoards}">
                 <tr>
-                    <td class="board-icon"><img src="${ctx}/images/folder.png" alt=""></td>
-                    <td><a href="${ctx}/list?bid=15">灌水乐园</a></td>
+                    <td class="board-icon"><img src="${pageContext.request.contextPath}/assets/images/board.gif" alt=""></td>
+                    <td><a href="${pageContext.request.contextPath}/post/list?bid=15">灌水乐园</a></td>
                     <td>25</td>
                     <td>
-                        <a href="${ctx}/post/detail?id=4001">你好</a>
+                        <a href="${pageContext.request.contextPath}/post/detail?id=4001">你好</a>
                         <span class="tip">accp [ 2007-09-27 15:09 ]</span>
                     </td>
                 </tr>

--- a/src/main/webapp/WEB-INF/views/list.jsp
+++ b/src/main/webapp/WEB-INF/views/list.jsp
@@ -1,31 +1,87 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c"   uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"  %>
-<%@ include file="/WEB-INF/views/_inc/header.jspf" %>
 
-<div class="breadcrumb">
-  >> 论坛首页 >> ${board.name}
-  <c:if test="${not empty sessionScope.user}">
-    <a class="btn primary right" href="${pageContext.request.contextPath}/post/new?bid=${board.bid}">发表帖子</a>
-  </c:if>
+<c:choose>
+    <c:when test="${not empty board}">
+        <c:set var="breadcrumb" scope="request">
+            >> <a href="${pageContext.request.contextPath}/post/list?bid=${board.id}"><c:out value="${board.name}"/></a>
+        </c:set>
+    </c:when>
+    <c:otherwise>
+        <c:set var="breadcrumb" scope="request">>> 全部帖子</c:set>
+    </c:otherwise>
+</c:choose>
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>
+        <c:choose>
+            <c:when test="${not empty board}"><c:out value="${board.name}"/> - 斑马教育 论坛</c:when>
+            <c:otherwise>帖子列表 - 斑马教育 论坛</c:otherwise>
+        </c:choose>
+    </title>
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/assets/css/style.css">
+</head>
+<body>
+<jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
+
+<div class="wrap">
+    <div class="board">
+        <div class="hd" style="display:flex;justify-content:space-between;align-items:center;">
+            <span>
+                <c:choose>
+                    <c:when test="${not empty board}"><c:out value="${board.name}"/></c:when>
+                    <c:otherwise>全部帖子</c:otherwise>
+                </c:choose>
+            </span>
+            <c:if test="${not empty sessionScope.user}">
+                <c:choose>
+                    <c:when test="${not empty board}">
+                        <c:url var="newPostUrl" value="/post/new">
+                            <c:param name="bid" value="${board.id}"/>
+                        </c:url>
+                    </c:when>
+                    <c:otherwise>
+                        <c:url var="newPostUrl" value="/post/new"/>
+                    </c:otherwise>
+                </c:choose>
+                <a class="btn" href="${pageContext.request.contextPath}${newPostUrl}">发表帖子</a>
+            </c:if>
+        </div>
+
+        <table class="table">
+            <thead>
+            <tr>
+                <th>主题</th>
+                <th style="width:140px;">作者</th>
+                <th style="width:120px;">回复</th>
+                <th style="width:180px;">发布时间</th>
+            </tr>
+            </thead>
+            <tbody>
+            <c:forEach var="p" items="${posts}">
+                <tr>
+                    <td>
+                        <a href="${pageContext.request.contextPath}/post/detail?id=${p.id}"><c:out value="${p.title}"/></a>
+                </td>
+                    <td><c:out value="${p.author}"/></td>
+                    <td><c:out value="${p.replyCount}"/></td>
+                    <td><fmt:formatDate value="${p.createTime}" pattern="yyyy-MM-dd HH:mm"/></td>
+                </tr>
+            </c:forEach>
+            <c:if test="${empty posts}">
+                <tr>
+                    <td colspan="4" style="text-align:center;color:#7d97ba;">暂无帖子，快来抢沙发吧！</td>
+                </tr>
+            </c:if>
+            </tbody>
+        </table>
+    </div>
 </div>
 
-<table class="table">
-  <thead>
-  <tr><th>主题</th><th width="160">最后发表</th></tr>
-  </thead>
-  <tbody>
-  <c:forEach var="p" items="${posts}">
-    <tr>
-      <td>
-        <a href="${pageContext.request.contextPath}/post/detail?id=${p.tid}">${p.title}</a>
-      </td>
-      <td>
-        <fmt:formatDate value="${p.updateTime}" pattern="yyyy-MM-dd HH:mm" />
-      </td>
-    </tr>
-  </c:forEach>
-  </tbody>
-</table>
-
-<%@ include file="/WEB-INF/views/_inc/footer.jspf" %>
+<jsp:include page="/WEB-INF/views/_inc/footer.jspf"/>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -1,13 +1,12 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<c:set var="ctx" value="${pageContext.request.contextPath}" />
 
 <!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
     <title>登录 - 斑马教育 论坛</title>
-    <link rel="stylesheet" href="${ctx}/style.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/assets/css/style.css">
 </head>
 <body>
 <jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
@@ -15,9 +14,9 @@
 <div class="panel">
     <div class="hd">登录</div>
     <div class="bd">
-        <form class="form" method="post" action="${ctx}/auth/login">
+        <form class="form" method="post" action="${pageContext.request.contextPath}/auth/login">
             <c:if test="${not empty requestScope.msg}">
-                <div class="tip" style="margin:4px 0 12px;color:#c00;">${msg}</div>
+                <div class="tip" style="margin:4px 0 12px;color:#c00;"><c:out value="${msg}"/></div>
             </c:if>
 
             <div class="row">
@@ -30,7 +29,7 @@
             </div>
             <div class="actions">
                 <button class="btn" type="submit">登录</button>
-                <a class="btn secondary" href="${ctx}/auth/register">去注册</a>
+                <a class="btn secondary" href="${pageContext.request.contextPath}/auth/register">去注册</a>
             </div>
         </form>
     </div>

--- a/src/main/webapp/WEB-INF/views/post.jsp
+++ b/src/main/webapp/WEB-INF/views/post.jsp
@@ -1,13 +1,14 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<c:set var="ctx" value="${pageContext.request.contextPath}" />
+
+<c:set var="breadcrumb" scope="request">>> 发布新帖</c:set>
 
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
   <title>发帖 - 斑马教育 论坛</title>
-  <link rel="stylesheet" href="${ctx}/style.css">
+  <link rel="stylesheet" href="${pageContext.request.contextPath}/assets/css/style.css">
 </head>
 <body>
 <jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
@@ -16,9 +17,15 @@
   <div class="board">
     <div class="hd">发表帖子</div>
     <div class="form" style="width:940px;">
-      <form method="post" action="${ctx}/post/add">
+      <form method="post" action="${pageContext.request.contextPath}/post/create">
         <!-- 保留 bid（所属板块） -->
-        <input type="hidden" name="bid" value="${param.bid}" />
+        <input type="hidden" name="bid" value="${not empty param.bid ? param.bid : boardId}" />
+        <c:if test="${not empty board}">
+          <div class="tip" style="margin-left:80px;margin-bottom:12px;">将发布到：<c:out value="${board.name}"/></div>
+        </c:if>
+        <c:if test="${not empty requestScope.msg}">
+          <div class="tip" style="margin-left:80px;margin-bottom:12px;color:#c00;"><c:out value="${msg}"/></div>
+        </c:if>
         <div class="row">
           <label>标 题</label>
           <input type="text" name="title" maxlength="100" required>

--- a/src/main/webapp/WEB-INF/views/post_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/post_detail.jsp
@@ -1,48 +1,79 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c"   uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"  %>
-<%@ include file="/WEB-INF/views/_inc/header.jspf" %>
 
-<div class="breadcrumb">
-  >> 论坛首页 >> ${board.name} >> ${post.title}
-</div>
-
-<article class="post">
-  <header class="post-header">
-    <h2>${post.title}</h2>
-    <div class="meta">
-      <span>作者：${post.authorName}</span>
-      <span class="sep">|</span>
-      <span>时间：<fmt:formatDate value="${post.createTime}" pattern="yyyy-MM-dd HH:mm"/></span>
-      <c:if test="${sessionScope.user != null && sessionScope.user.id == post.uid}">
-        <span class="sep">|</span>
-        <a class="danger" href="${pageContext.request.contextPath}/post/delete?id=${post.tid}"
-           onclick="return confirm('确定删除该帖子？');">删除</a>
-      </c:if>
-    </div>
-  </header>
-  <div class="content">${post.content}</div>
-</article>
-
-<section class="replies">
-  <h3>回复</h3>
-  <c:forEach var="r" items="${replies}">
-    <div class="reply">
-      <div class="author">${r.userName}</div>
-      <div class="time"><fmt:formatDate value="${r.createTime}" pattern="yyyy-MM-dd HH:mm"/></div>
-      <div class="content">${r.content}</div>
-    </div>
-  </c:forEach>
-</section>
-
-<c:if test="${not empty sessionScope.user}">
-  <section class="reply-form">
-    <form action="${pageContext.request.contextPath}/comment/add" method="post">
-      <input type="hidden" name="postId" value="${post.tid}">
-      <textarea name="content" rows="6" maxlength="1000" required placeholder="写下你的回复……"></textarea>
-      <button type="submit" class="btn primary">提交</button>
-    </form>
-  </section>
+<c:if test="${not empty post}">
+    <c:set var="breadcrumb" scope="request">
+        >> <a href="${pageContext.request.contextPath}/post/list?bid=${post.boardId}"><c:out value="${post.boardName}"/></a>
+        >> <c:out value="${post.title}"/>
+    </c:set>
 </c:if>
 
-<%@ include file="/WEB-INF/views/_inc/footer.jspf" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title><c:out value="${post.title}"/> - 斑马教育 论坛</title>
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/assets/css/style.css">
+</head>
+<body>
+<jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
+
+<div class="wrap">
+    <article class="post">
+        <header class="post-header">
+            <h2><c:out value="${post.title}"/></h2>
+            <div class="meta">
+                <span>作者：<c:out value="${post.author}"/></span>
+                <span class="sep">|</span>
+                <span>时间：<fmt:formatDate value="${post.createTime}" pattern="yyyy-MM-dd HH:mm"/></span>
+                <c:if test="${sessionScope.user != null && sessionScope.user.id == post.authorId}">
+                    <span class="sep">|</span>
+                    <a class="danger" href="${pageContext.request.contextPath}/post/delete?id=${post.id}">删除</a>
+                </c:if>
+            </div>
+        </header>
+        <div class="content"><c:out value="${post.content}"/></div>
+    </article>
+
+    <section class="replies">
+        <h3>回复</h3>
+        <c:forEach var="r" items="${replies}">
+            <div class="reply">
+                <div class="author"><c:out value="${r.author}"/></div>
+                <div class="time"><fmt:formatDate value="${r.createTime}" pattern="yyyy-MM-dd HH:mm"/></div>
+                <div class="content"><c:out value="${r.content}"/></div>
+            </div>
+        </c:forEach>
+        <c:if test="${empty replies}">
+            <div class="reply empty">暂时还没有回复，欢迎抢沙发！</div>
+        </c:if>
+    </section>
+
+    <c:if test="${not empty sessionScope.user}">
+        <section class="reply-form">
+            <c:if test="${param.error == 'empty'}">
+                <div class="tip" style="color:#c00;margin-bottom:12px;">回复内容不能为空。</div>
+            </c:if>
+            <c:if test="${param.error == 'toolong'}">
+                <div class="tip" style="color:#c00;margin-bottom:12px;">回复内容不能超过 1000 字。</div>
+            </c:if>
+            <form action="${pageContext.request.contextPath}/comment/add" method="post">
+                <input type="hidden" name="postId" value="${post.id}">
+                <textarea name="content" rows="6" maxlength="1000" required placeholder="写下你的回复……"></textarea>
+                <div class="actions">
+                    <button type="submit" class="btn">提交</button>
+                </div>
+            </form>
+        </section>
+    </c:if>
+    <c:if test="${empty sessionScope.user}">
+        <div class="tip" style="margin-top:16px;">
+            请先<a href="${pageContext.request.contextPath}/auth/login">登录</a>后再回复。
+        </div>
+    </c:if>
+</div>
+
+<jsp:include page="/WEB-INF/views/_inc/footer.jspf"/>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/register.jsp
+++ b/src/main/webapp/WEB-INF/views/register.jsp
@@ -1,13 +1,12 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<c:set var="ctx" value="${pageContext.request.contextPath}" />
 
 <!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
     <title>注册 - 斑马教育 论坛</title>
-    <link rel="stylesheet" href="${ctx}/style.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/assets/css/style.css">
 </head>
 <body>
 <jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
@@ -15,7 +14,10 @@
 <div class="panel">
     <div class="hd">注册</div>
     <div class="bd">
-        <form class="form" method="post" action="${ctx}/auth/register">
+        <form class="form" method="post" action="${pageContext.request.contextPath}/auth/register">
+            <c:if test="${not empty requestScope.msg}">
+                <div class="tip" style="margin:4px 0 12px;color:#c00;"><c:out value="${msg}"/></div>
+            </c:if>
             <div class="row">
                 <label>用户名</label>
                 <input type="text" name="username" required>
@@ -38,10 +40,10 @@
             <div class="row" style="align-items:flex-start;">
                 <label>选择头像</label>
                 <div class="avatars">
-                    <c:forEach var="i" begin="1" end="12">
+                    <c:forEach var="i" begin="1" end="15">
                         <label class="avatar">
-                            <input type="radio" name="headimage" value="/images/avatars/${i}.gif" <c:if test="${i==1}">checked</c:if> />
-                            <img src="${ctx}/images/avatars/${i}.gif" alt="头像${i}">
+                            <input type="radio" name="headimage" value="/assets/images/${i}.gif" <c:if test="${i==1}">checked</c:if> />
+                            <img src="${pageContext.request.contextPath}/assets/images/${i}.gif" alt="头像${i}">
                         </label>
                     </c:forEach>
                 </div>

--- a/src/main/webapp/assets/css/style.css
+++ b/src/main/webapp/assets/css/style.css
@@ -40,10 +40,12 @@ a:hover{text-decoration:underline}
 .form .row textarea{height:280px;resize:vertical}
 .actions{margin-top:10px}
 .btn{
-	display:inline-block;min-width:72px;text-align:center;padding:7px 14px;border-radius:3px;
-	border:1px solid #2f6ab1;background:#3d7bd3;color:#fff;cursor:pointer
+        display:inline-block;min-width:72px;text-align:center;padding:7px 14px;border-radius:3px;
+        border:1px solid #2f6ab1;background:#3d7bd3;color:#fff;cursor:pointer
 }
 .btn.secondary{background:#f8fbff;color:#2f6ab1;border-color:#bcd3ef}
+.btn.danger{background:#d9534f;border-color:#c9302c}
+.btn.danger:hover{background:#c9302c;color:#fff}
 .tip{color:#8aa3c4;font-size:12px}
 
 /* 登录/注册 */
@@ -56,3 +58,22 @@ a:hover{text-decoration:underline}
 .avatar{display:flex;align-items:center;gap:6px}
 .avatar img{width:54px;height:54px;border:1px solid #d9e8f9;border-radius:4px;background:#fff}
 .footer{margin:30px 0 40px;text-align:center;color:#7d97ba}
+
+/* 帖子详情 */
+.post{margin:20px 0;padding:18px;border:1px solid #cfe0f3;border-radius:4px;background:#fff}
+.post-header{border-bottom:1px solid #e5effd;padding-bottom:12px;margin-bottom:12px}
+.post-header h2{margin:0;font-size:22px;color:#2f4f7f}
+.post-header .meta{color:#7d8da9;font-size:13px}
+.post-header .meta .sep{margin:0 8px;color:#c5d2e8}
+.post .content{white-space:pre-wrap;line-height:1.8;color:#333}
+
+.replies{margin:24px 0}
+.replies h3{margin:0 0 12px;font-size:18px;color:#2f4f7f}
+.reply{border:1px solid #e1ecfb;border-radius:4px;padding:12px;margin-bottom:12px;background:#f9fbff}
+.reply.empty{text-align:center;color:#7d97ba;font-style:italic}
+.reply .author{font-weight:600;color:#355686}
+.reply .time{color:#7d8da9;font-size:12px;margin:4px 0 8px}
+.reply .content{white-space:pre-wrap;color:#333}
+
+.reply-form textarea{width:100%;padding:10px;border:1px solid #cfe0f3;border-radius:4px;resize:vertical;min-height:160px}
+.reply-form .actions{margin-top:10px}


### PR DESCRIPTION
## Summary
- introduce a BoardDao and update PostServlet/PostDao to look up board metadata, filter lists, and load replies with the database-backed user model
- harden comment submission validation and refresh the JSP templates to use the correct asset paths, breadcrumbs, and escaped output
- extend the shared stylesheet to style post details, replies, and destructive actions so the UI renders correctly again

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68ce25beb7fc832887b327eb671df080