### PR TITLE
Switch shared JSP fragments to translation-time includes

### DIFF
--- a/src/main/webapp/WEB-INF/views/_inc/footer.jspf
+++ b/src/main/webapp/WEB-INF/views/_inc/footer.jspf
@@ -1,3 +1,2 @@
-<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!-- 不要在片段里写 page/taglib 指令 -->
 <div class="footer gray">2018 Tokyo Banma education Co.,Ltd 版权所有</div>

--- a/src/main/webapp/WEB-INF/views/_inc/header.jspf
+++ b/src/main/webapp/WEB-INF/views/_inc/header.jspf
@@ -1,4 +1,3 @@
-<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!-- 不要在片段里写 page/taglib 指令 -->
 <div class="logo-bar">
     <img src="${ctx}/assets/images/logo.png" width="123" height="45" alt="斑马学员论坛" />

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -9,7 +9,7 @@
     <link rel="stylesheet" type="text/css" href="${ctx}/assets/css/style.css">
 </head>
 <body>
-<jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/header.jspf" %>
 <div class="t">
     <table cellSpacing="0" cellPadding="0" width="100%">
         <tbody>
@@ -198,6 +198,6 @@
         </tbody>
     </table>
 </div>
-<jsp:include page="/WEB-INF/views/_inc/footer.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/footer.jspf" %>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/list.jsp
+++ b/src/main/webapp/WEB-INF/views/list.jsp
@@ -10,7 +10,7 @@
     <link rel="stylesheet" type="text/css" href="${ctx}/assets/css/style.css">
 </head>
 <body>
-<jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/header.jspf" %>
 <div class="nav">&gt;&gt;<b><a href="${ctx}/">论坛首页</a></b>&gt;&gt; <b>帖子列表</b></div>
 <div class="list-actions">
     <c:if test="${not empty sessionScope.user}">
@@ -170,6 +170,6 @@
         </tbody>
     </table>
 </div>
-<jsp:include page="/WEB-INF/views/_inc/footer.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/footer.jspf" %>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -22,7 +22,7 @@
     </script>
 </head>
 <body>
-<jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/header.jspf" %>
 <div class="nav">&gt;&gt;<b><a href="${ctx}/">论坛首页</a></b></div>
 <c:if test="${not empty msg}">
     <div class="notice">${msg}</div>
@@ -34,6 +34,6 @@
         <input class="btn" tabindex="6" value="登 录" type="submit">
     </form>
 </div>
-<jsp:include page="/WEB-INF/views/_inc/footer.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/footer.jspf" %>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/post.jsp
+++ b/src/main/webapp/WEB-INF/views/post.jsp
@@ -26,7 +26,7 @@
     </script>
 </head>
 <body>
-<jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/header.jspf" %>
 <div class="nav">&gt;&gt;<b><a href="${ctx}/">论坛首页</a></b></div>
 <div class="nav">&gt;&gt; <b>发表帖子</b></div>
 <c:if test="${not empty msg}">
@@ -59,6 +59,6 @@
         </div>
     </form>
 </div>
-<jsp:include page="/WEB-INF/views/_inc/footer.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/footer.jspf" %>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/post_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/post_detail.jsp
@@ -10,7 +10,7 @@
     <link rel="stylesheet" type="text/css" href="${ctx}/assets/css/style.css">
 </head>
 <body>
-<jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/header.jspf" %>
 <div class="nav">&gt;&gt;<b><a href="${ctx}/">论坛首页</a></b>&gt;&gt; <b>${post.boardName}</b></div>
 <div class="list-actions">
     <a href="#reply-form"><img src="${ctx}/assets/images/reply.gif" alt="回复"></a>
@@ -71,6 +71,6 @@
         </form>
     </div>
 </c:if>
-<jsp:include page="/WEB-INF/views/_inc/footer.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/footer.jspf" %>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/register.jsp
+++ b/src/main/webapp/WEB-INF/views/register.jsp
@@ -26,7 +26,7 @@
     </script>
 </head>
 <body>
-<jsp:include page="/WEB-INF/views/_inc/header.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/header.jspf" %>
 <div class="nav">&gt;&gt;<b><a href="${ctx}/">论坛首页</a></b></div>
 <c:if test="${not empty msg}">
     <div class="notice">${msg}</div>
@@ -49,6 +49,6 @@
         <input class="btn" tabindex="4" value="注 册" type="submit">
     </form>
 </div>
-<jsp:include page="/WEB-INF/views/_inc/footer.jspf"/>
+<%@ include file="/WEB-INF/views/_inc/footer.jspf" %>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace runtime JSP includes for the shared header and footer with translation-time includes in each page that uses them
- remove duplicate page directives from the header and footer fragments now that they are statically merged into the parent pages

## Testing
- mvn -q -DskipTests package *(fails: network is unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68ce874d4eac83289bffb028aa8c90c0