### PR TITLE
Fix database configuration handling

### DIFF
--- a/src/main/java/com/banma/forum/dao/UserDao.java
+++ b/src/main/java/com/banma/forum/dao/UserDao.java
@@ -5,20 +5,8 @@ import com.banma.forum.model.User;
 import java.sql.*;
 
 public class UserDao {
-    // 建议抽成常量，避免每次拼接字符串
-    private static final String URL =
-            "jdbc:mysql://127.0.0.1:3306/banma_forum"
-                    + "?useUnicode=true"
-                    + "&characterEncoding=UTF-8"     // JDBC 端用 UTF-8
-                    + "&useSSL=false"
-                    + "&serverTimezone=Asia/Shanghai"
-                    + "&allowPublicKeyRetrieval=true";
-    private static final String USER = "root";
-    private static final String PASS = "alalapi";
-
-    private Connection getConn() throws Exception {
-        Class.forName("com.mysql.cj.jdbc.Driver");
-        return DriverManager.getConnection(URL, USER, PASS);
+    private Connection getConn() throws SQLException {
+        return DB.getConnection();
     }
 
     /** 根据用户名查找用户 */

--- a/src/main/resources/jdbc.properties
+++ b/src/main/resources/jdbc.properties
@@ -1,4 +1,4 @@
-jdbc.url=jdbc:mysql://localhost:3306/banma_forum?useSSL=false&useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai
+jdbc.url=jdbc:mysql://localhost:3306/banma_forum?useSSL=false&useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
 jdbc.user=root
 jdbc.password=alalapi
 jdbc.driver=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## Summary
- reuse the shared DB utility in `UserDao` so database credentials come from `jdbc.properties`
- correct the JDBC URL in `jdbc.properties` and add `allowPublicKeyRetrieval` to avoid connection issues

## Testing
- `mvn -q -DskipTests package` *(fails: network is unreachable while downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0dad1b3c8328bf8664304e2ad051