### PR TITLE
Make header logo link back to home page

### DIFF
--- a/src/main/webapp/WEB-INF/views/_inc/header.jsp
+++ b/src/main/webapp/WEB-INF/views/_inc/header.jsp
@@ -7,7 +7,9 @@
 
 <!-- 顶部 Logo -->
 <div class="logo-bar">
-    <img src="${ctx}/assets/images/logo.png" width="123" height="45" alt="斑马学员论坛">
+    <a href="${ctx}/home">
+        <img src="${ctx}/assets/images/logo.png" width="123" height="45" alt="斑马学员论坛">
+    </a>
 </div>
 
 <!-- 登录/注册/登出状态条 -->


### PR DESCRIPTION
## Summary
- wrap the header logo image in an anchor so clicking it returns to the home page

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf3f1c1a7c83288c996e043dcee06c