### PR TITLE
Fix asset version lookup in home JSP

### DIFF
--- a/src/main/java/com/banma/forum/controller/HomeServlet.java
+++ b/src/main/java/com/banma/forum/controller/HomeServlet.java
@@ -20,6 +20,7 @@ public class HomeServlet extends HttpServlet {
             req.setAttribute("javaBoards", boardDao.listChildrenWithStats(6)); // 读取 Java 板块信息
             req.setAttribute("dbBoards", boardDao.listChildrenWithStats(11)); // 读取数据库板块信息
             req.setAttribute("funBoards", boardDao.listChildrenWithStats(14)); // 读取兴趣板块信息
+            req.setAttribute("assetVersion", System.currentTimeMillis()); // 提供静态资源版本号，避免缓存导致的样式更新不及时
         } catch (SQLException e) { // 捕获数据库异常
             if (isConnectionFailure(e)) { // 判断是否为连接失败
                 log("数据库连接失败", e); // 记录日志

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -6,6 +6,10 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%-- 读取当前应用的上下文路径，供页面拼接链接 --%>
 <c:set var="ctx" value="${pageContext.request.contextPath}" />
+<%-- 如果请求没有带入静态资源版本号，则使用当前会话的最后访问时间兜底 --%>
+<c:if test="${empty assetVersion}">
+    <c:set var="assetVersion" value="${pageContext.session.lastAccessedTime}" />
+</c:if>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3c.org/TR/1999/REC-html401-19991224/loose.dtd">
 <html>
 <head>
@@ -13,8 +17,11 @@
     <title>欢迎访问斑马学员论坛</title>
     <!-- 指定页面的内容类型与编码 -->
     <meta charset="UTF-8">
-    <!-- 引入站点统一的样式文件 -->
-    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=${pageContext.request.time}">
+    <!-- 构建携带版本号的样式文件链接，避免浏览器缓存导致的页面样式异常 -->
+    <c:url value="/static/css/main.css" var="mainCssUrl">
+        <c:param name="v" value="${assetVersion}" />
+    </c:url>
+    <link rel="stylesheet" type="text/css" href="${mainCssUrl}">
 </head>
 <body>
 <%-- 引入通用页头 --%>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,4 +1,4 @@
 <%-- 指定 JSP 输出的内容类型和字符集，避免中文乱码 --%>
-<%@ page contentType="text/html;charset=UTF-8" %>
+<%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" %>
 <%-- 默认访问根路径时，立即转发到 /home，让 HomeServlet 处理 --%>
 <jsp:forward page="/home"/>


### PR DESCRIPTION
## Summary
- provide a request scoped assetVersion value from HomeServlet so JSPs no longer read a non-existent property
- build the stylesheet URL in home.jsp with JSTL parameters and a fallback value when the attribute is absent
- declare UTF-8 page encoding in index.jsp to avoid garbled Chinese comments when errors render the JSP source

## Testing
- not run (JSP-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e3518a0e48328b0c145e5b23222a7)