### PR TITLE
Fix JSP cache busting parameter

### DIFF
--- a/src/main/webapp/WEB-INF/views/delete.jsp
+++ b/src/main/webapp/WEB-INF/views/delete.jsp
@@ -12,7 +12,7 @@
     <!-- 指定内容类型 -->
     <meta charset="UTF-8">
     <!-- 引入通用样式 -->
-    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=${pageContext.request.time}">
+    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=<%= System.currentTimeMillis() %>">
 </head>
 <body>
 <%-- 引入统一页头 --%>

--- a/src/main/webapp/WEB-INF/views/list.jsp
+++ b/src/main/webapp/WEB-INF/views/list.jsp
@@ -18,7 +18,7 @@
     <!-- 声明内容类型 -->
     <meta charset="UTF-8">
     <!-- 引入通用样式 -->
-    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=${pageContext.request.time}">
+    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=<%= System.currentTimeMillis() %>">
 </head>
 <body>
 <%-- 引入页头 --%>

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -12,7 +12,7 @@
     <!-- 指定内容类型 -->
     <meta charset="UTF-8">
     <!-- 引入通用样式 -->
-    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=${pageContext.request.time}">
+    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=<%= System.currentTimeMillis() %>">
     <script type="text/javascript">
         // 登录表单的简单校验
         function check() {

--- a/src/main/webapp/WEB-INF/views/post.jsp
+++ b/src/main/webapp/WEB-INF/views/post.jsp
@@ -14,7 +14,7 @@
     <!-- 明确声明内容类型 -->
     <meta charset="UTF-8">
     <!-- 引入通用样式 -->
-    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=${pageContext.request.time}">
+    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=<%= System.currentTimeMillis() %>">
     <script type="text/javascript">
         // 表单提交前的简单前端校验
         function check(){

--- a/src/main/webapp/WEB-INF/views/post_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/post_detail.jsp
@@ -16,7 +16,7 @@
     <!-- 指定内容类型 -->
     <meta charset="UTF-8">
     <!-- 引入全站样式 -->
-    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=${pageContext.request.time}">
+    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=<%= System.currentTimeMillis() %>">
 </head>
 <body>
 <%-- 引入通用页头 --%>

--- a/src/main/webapp/WEB-INF/views/register.jsp
+++ b/src/main/webapp/WEB-INF/views/register.jsp
@@ -12,7 +12,7 @@
     <!-- 指定内容类型 -->
     <meta charset="UTF-8">
     <!-- 引入通用样式 -->
-    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=${pageContext.request.time}">
+    <link rel="stylesheet" type="text/css" href="<c:url value='/static/css/main.css'/>?v=<%= System.currentTimeMillis() %>">
     <script type="text/javascript">
         // 注册表单的基础校验
         function check() {


### PR DESCRIPTION
## Summary
- replace the invalid `${pageContext.request.time}` expression with a runtime timestamp for stylesheet cache busting across forum JSPs

## Testing
- `mvn -DskipTests package`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e3658bec08328b77e27ca9a21412e)